### PR TITLE
Add another solution (a bit faster)

### DIFF
--- a/DigraphsLookup.Tests/LookupTests.cs
+++ b/DigraphsLookup.Tests/LookupTests.cs
@@ -16,6 +16,8 @@ namespace DigraphsLookup.Tests
 		{
 			yield return new SubstringPairsDigraphsLookup();
 			yield return new BitShiftingBinarySearchDigraphsLookup();
+			yield return new MemoryArraySearchDigraphsLookup();
+			yield return new MemoryArraySearchDigraphsLookupV2();
 		}
 
 		[Test]

--- a/DigraphsLookup/MemoryArraySearchDigraphsLookup.cs
+++ b/DigraphsLookup/MemoryArraySearchDigraphsLookup.cs
@@ -1,0 +1,65 @@
+﻿using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DigraphsLookup
+{
+	public class MemoryArraySearchDigraphsLookup : IDigraphsLookup
+	{
+		private readonly int[] _result = new int[256 * 256];
+		private readonly bool[] _searchedDigraph = new bool[256 * 256];
+
+		private static int DigraphToIndex(string digraph)
+		{
+			var digraphBytes = Encoding.ASCII.GetBytes(digraph);
+			return digraphBytes[0] + digraphBytes[1] * 256;
+		}
+
+		private void AddDigraph(string digraph)
+		{
+			_searchedDigraph[DigraphToIndex(digraph)] = true;
+		}
+
+		public async Task<LookupResult[]> LookupAsync(Stream stream, params string[] digraphs)
+		{
+			for (var i = 0; i < _result.Length; i++)
+			{
+				_result[i] = 0;
+			}
+
+			for (var i = 0; i < _searchedDigraph.Length; i++)
+			{
+				_searchedDigraph[i] = false;
+			}
+
+			foreach (var digraph in digraphs)
+			{
+				AddDigraph(digraph);
+			}
+
+			var bytes = new byte[stream.Length];
+			await stream.ReadAsync(bytes, 0, (int)stream.Length);
+
+			var first = bytes[0];
+			for (var i = 1; i < bytes.Length; i++)
+			{
+				var second = bytes[i];
+
+				if (_searchedDigraph[first + second * 256])
+				{
+					_result[first + second * 256]++;
+				}
+
+				first = second;
+			}
+
+			var result = new LookupResult[digraphs.Length];
+			for (var i = 0; i < digraphs.Length; i++)
+			{
+				var index = DigraphToIndex(digraphs[i]);
+				result[i] = new LookupResult(digraphs[i], _result[index]);
+			}
+			return result;
+		}
+	}
+}

--- a/DigraphsLookup/MemoryArraySearchDigraphsLookupV2.cs
+++ b/DigraphsLookup/MemoryArraySearchDigraphsLookupV2.cs
@@ -1,0 +1,46 @@
+﻿using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DigraphsLookup
+{
+	public class MemoryArraySearchDigraphsLookupV2 : IDigraphsLookup
+	{
+		private readonly int[] _result = new int[256 * 256];
+
+		private static int DigraphToIndex(string digraph)
+		{
+			var digraphBytes = Encoding.ASCII.GetBytes(digraph);
+			return digraphBytes[0] + digraphBytes[1] * 256;
+		}
+
+		public async Task<LookupResult[]> LookupAsync(Stream stream, params string[] digraphs)
+		{
+			for (var i = 0; i < _result.Length; i++)
+			{
+				_result[i] = 0;
+			}
+
+			var bytes = new byte[stream.Length];
+			await stream.ReadAsync(bytes, 0, (int)stream.Length);
+
+			var first = bytes[0];
+			for (var i = 1; i < bytes.Length; i++)
+			{
+				var second = bytes[i];
+
+				_result[first + second * 256]++;
+
+				first = second;
+			}
+
+			var result = new LookupResult[digraphs.Length];
+			for (var i = 0; i < digraphs.Length; i++)
+			{
+				var index = DigraphToIndex(digraphs[i]);
+				result[i] = new LookupResult(digraphs[i], _result[index]);
+			}
+			return result;
+		}
+	}
+}


### PR DESCRIPTION
> Performance (SubstringPairsDigraphsLookup):
>   1000 runs
>   17128ms total run time
>   Average time: 0.017128
>   | Min | 25% | 50% | 75% | 95% | Max |
>   | 016 | 017 | 017 | 017 | 019 | 022 |

> Performance (BitShiftingBinarySearchDigraphsLookup):
>   1000 runs
>   1154ms total run time
>   Average time: 0.001154
>   | Min | 25% | 50% | 75% | 95% | Max |
>   | 001 | 001 | 001 | 001 | 002 | 002 |

> Performance (MemoryArraySearchDigraphsLookup):
>   1000 runs
>   59ms total run time
>   Average time: 5.9E-05
>   | Min | 25% | 50% | 75% | 95% | Max |
>   | 000 | 000 | 000 | 000 | 001 | 001 |

> Performance (MemoryArraySearchDigraphsLookupV2):
>   1000 runs
>   70ms total run time
>   Average time: 7E-05
>   | Min | 25% | 50% | 75% | 95% | Max |
>   | 000 | 000 | 000 | 000 | 001 | 001 |